### PR TITLE
Update README to use Fishjam (rebranding)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
 
 ## Components
 
-The repository consists of 2 separapable components:
+The repository consists of 3 separapable components:
 
-- `FishjamClientSdk` - Fishjam client fully compatible with `Fishjam`, responsible for exchaning media events and receiving media streams which then are presented to the user
-- `FishjamCLientDemo` - Demo application utilizing `Fishjam` client
+- `JellyfishClientSdk` - Fishjam client fully compatible with `Fishjam`, responsible for exchaning media events and receiving media streams which then are presented to the user
+- `JellyfishCLientDemo` - Demo application utilizing `Fishjam` client
+- `MembraneRTC` - iOS webrtc client
 
 ### Example App
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 # Fishjam iOS Client
-[Fishjam](https://github.com/jellyfish-dev/jellyfish) Client library for iOS apps written in Swift.
+[Fishjam](https://github.com/fishjam-dev/fishjam) Client library for iOS apps written in Swift.
 
 ## Components
 
@@ -17,7 +17,7 @@ Really simple App allowing to test `Fishjam client` functionalities. It consist 
 - Room's screen consisting of set of control buttons and an area where participants' videos get displayed
 
 ## Documentation
-API documentation is available [here](https://jellyfish-dev.github.io/ios-client-sdk/documentation/jellyfishclientsdk/).
+API documentation is available [here](https://fishjam-dev.github.io/ios-client-sdk/documentation/fishjamclientsdk/).
 
 ## Installation
 
@@ -35,20 +35,20 @@ We welcome contributions to iOS Client SDK. Please report any bugs or issues you
 
 ## Fishjam Ecosystem
 
-|             |                                                                                                                                                                                                                                                              |
-| ----------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Client SDKs | [React](https://github.com/jellyfish-dev/react-client-sdk), [React Native](https://github.com/jellyfish-dev/react-native-client-sdk), [iOs](https://github.com/jellyfish-dev/ios-client-sdk), [Android](https://github.com/jellyfish-dev/android-client-sdk) |
-| Server SDKs | [Elixir](https://github.com/jellyfish-dev/elixir_server_sdk), [Python](https://github.com/jellyfish-dev/python-server-sdk), [OpenAPI](https://jellyfish-dev.github.io/jellyfish-docs/api_reference/rest_api)                                                 |
-| Services    | [Videoroom](https://github.com/jellyfish-dev/jellyfish_videoroom) - an example videoconferencing app written in elixir <br/> [Dashboard](https://github.com/jellyfish-dev/jellyfish-dashboard) - an internal tool used to showcase Fishjam's capabilities    |
-| Resources   | [Fishjam Book](https://jellyfish-dev.github.io/book/) - theory of the framework, [Docs](https://jellyfish-dev.github.io/jellyfish-docs/), [Tutorials](https://github.com/jellyfish-dev/jellyfish-clients-tutorials)                                          |
-| Membrane    | Fishjam is based on [Membrane](https://membrane.stream/), [Discord](https://discord.gg/nwnfVSY)                                                                                                                                                              |
-| Compositor  | [Compositor](https://github.com/membraneframework/membrane_video_compositor_plugin) - Fishjam plugin to transform video                                                                                                                                      |
-| Protobufs   | If you want to use Fishjam on your own, you can use our [protobufs](https://github.com/jellyfish-dev/protos)                                                                                                                                                 
+|             |                                                                                                                                                                                                                                                      |
+| ----------- |------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Client SDKs | [React](https://github.com/fishjam-dev/react-client-sdk), [React Native](https://github.com/fishjam-dev/react-native-client-sdk), [iOS](https://github.com/fishjam-dev/ios-client-sdk), [Android](https://github.com/fishjam-dev/android-client-sdk) |
+| Server SDKs | [Elixir](https://github.com/fishjam-dev/elixir_server_sdk), [Python](https://github.com/fishjam-dev/python-server-sdk), [OpenAPI](https://fishjam-dev.github.io/fishjam-docs/for_developers/api_reference/rest_api)                                  |
+| Services    | [Videoroom](https://github.com/fishjam-dev/fishjam-videoroom) - an example videoconferencing app written in elixir <br/> [Dashboard](https://github.com/fishjam-dev/fishjam-dashboard) - an internal tool used to showcase Fishjam's capabilities    |
+| Resources   | [Fishjam Book](https://fishjam-dev.github.io/book/) - theory of the framework, [Docs](https://fishjam-dev.github.io/fishjam-docs/), [Tutorials](https://github.com/fishjam-dev/fishjam-clients-tutorials)                                            |
+| Membrane    | Fishjam is based on [Membrane](https://membrane.stream/), [Discord](https://discord.gg/nwnfVSY)                                                                                                                                                      |
+| Compositor  | [Compositor](https://github.com/membraneframework/membrane_video_compositor_plugin) - Membrane plugin to transform video                                                                                                                             |
+| Protobufs   | If you want to use Fishjam on your own, you can use our [protobufs](https://github.com/fishjam-dev/protos)                                                                                                                                           
 
 ## Copyright and License
 
-Copyright 2023, [Software Mansion](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=jellyfish)
+Copyright 2023, [Software Mansion](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=fishjam)
 
-[![Software Mansion](https://logo.swmansion.com/logo?color=white&variant=desktop&width=200&tag=membrane-github)](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=jellyfish)
+[![Software Mansion](https://logo.swmansion.com/logo?color=white&variant=desktop&width=200&tag=membrane-github)](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=fishjam)
 
 Licensed under the [Apache License, Version 2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,29 +1,27 @@
 
-# Jellyfish iOS Client
-
-[Jellyfish](https://github.com/jellyfish-dev/jellyfish) Client library for iOS apps written in Swift.
+# Fishjam iOS Client
+[Fishjam](https://github.com/jellyfish-dev/jellyfish) Client library for iOS apps written in Swift.
 
 ## Components
 
 The repository consists of 2 separapable components:
 
-- `JellyfishClientSdk` - Jellyfish client fully compatible with `Jellyfish`, responsible for exchaning media events and receiving media streams which then are presented to the user
-- `JellyfishCLientDemo` - Demo application utilizing `Jellyfish` client
+- `FishjamClientSdk` - Fishjam client fully compatible with `Fishjam`, responsible for exchaning media events and receiving media streams which then are presented to the user
+- `FishjamCLientDemo` - Demo application utilizing `Fishjam` client
 
 ### Example App
 
-Really simple App allowing to test `Jellyfish client` functionalities. It consist of 2 screens:
+Really simple App allowing to test `Fishjam client` functionalities. It consist of 2 screens:
 
 - Joining screen where user passes peer token followed by join button click
 - Room's screen consisting of set of control buttons and an area where participants' videos get displayed
 
 ## Documentation
-
 API documentation is available [here](https://jellyfish-dev.github.io/ios-client-sdk/documentation/jellyfishclientsdk/).
 
 ## Installation
 
-Add JellyfishClientSDK dependency to your project.
+Add FishjamClientSDK dependency to your project.
 
 ## Developing
 
@@ -35,17 +33,17 @@ Add JellyfishClientSDK dependency to your project.
 
 We welcome contributions to iOS Client SDK. Please report any bugs or issues you find or feel free to make a pull request with your own bug fixes and/or features.
 
-## Jellyfish Ecosystem
+## Fishjam Ecosystem
 
 |             |                                                                                                                                                                                                                                                              |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| ----------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Client SDKs | [React](https://github.com/jellyfish-dev/react-client-sdk), [React Native](https://github.com/jellyfish-dev/react-native-client-sdk), [iOs](https://github.com/jellyfish-dev/ios-client-sdk), [Android](https://github.com/jellyfish-dev/android-client-sdk) |
 | Server SDKs | [Elixir](https://github.com/jellyfish-dev/elixir_server_sdk), [Python](https://github.com/jellyfish-dev/python-server-sdk), [OpenAPI](https://jellyfish-dev.github.io/jellyfish-docs/api_reference/rest_api)                                                 |
-| Services    | [Videoroom](https://github.com/jellyfish-dev/jellyfish_videoroom) - an example videoconferencing app written in elixir <br/> [Dashboard](https://github.com/jellyfish-dev/jellyfish-dashboard) - an internal tool used to showcase Jellyfish's capabilities   |
-| Resources   | [Jellyfish Book](https://jellyfish-dev.github.io/book/) - theory of the framework, [Docs](https://jellyfish-dev.github.io/jellyfish-docs/), [Tutorials](https://github.com/jellyfish-dev/jellyfish-clients-tutorials)                                        |
-| Membrane    | Jellyfish is based on [Membrane](https://membrane.stream/), [Discord](https://discord.gg/nwnfVSY)                                                                                                                                                            |
-| Compositor  | [Compositor](https://github.com/membraneframework/membrane_video_compositor_plugin) - Membrane plugin to transform video                                                                                                                                     |
-| Protobufs   | If you want to use Jellyfish on your own, you can use our [protobufs](https://github.com/jellyfish-dev/protos)
+| Services    | [Videoroom](https://github.com/jellyfish-dev/jellyfish_videoroom) - an example videoconferencing app written in elixir <br/> [Dashboard](https://github.com/jellyfish-dev/jellyfish-dashboard) - an internal tool used to showcase Fishjam's capabilities    |
+| Resources   | [Fishjam Book](https://jellyfish-dev.github.io/book/) - theory of the framework, [Docs](https://jellyfish-dev.github.io/jellyfish-docs/), [Tutorials](https://github.com/jellyfish-dev/jellyfish-clients-tutorials)                                          |
+| Membrane    | Fishjam is based on [Membrane](https://membrane.stream/), [Discord](https://discord.gg/nwnfVSY)                                                                                                                                                              |
+| Compositor  | [Compositor](https://github.com/membraneframework/membrane_video_compositor_plugin) - Fishjam plugin to transform video                                                                                                                                      |
+| Protobufs   | If you want to use Fishjam on your own, you can use our [protobufs](https://github.com/jellyfish-dev/protos)                                                                                                                                                 
 
 ## Copyright and License
 


### PR DESCRIPTION
Update README file to use new name - Fishjam